### PR TITLE
add fix for edge 15 css vars issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,10 @@ function cssVars(options = {}) {
 
     // Verify readyState to ensure all <link> and <style> nodes are available
     if (document.readyState !== 'loading') {
-        const hasNativeSupport = window.CSS && window.CSS.supports && window.CSS.supports('(--a: 0)');
+        // fix issues in edge 15 by updating permission check in native support
+        // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/
+        const hasNativeSupport = window.CSS && window.CSS.supports && window.CSS.supports('(--a: 0)') &&
+            window.navigator.userAgent.indexOf('Edge/15') === -1; 
 
         // Lacks native support or onlyLegacy 'false'
         if (!hasNativeSupport || !settings.onlyLegacy) {


### PR DESCRIPTION
Hi @jhildenbiddle!  Edge 15 has problems with support css variables in ::before and ::after pseudo elements https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/ . Its fixed in Edge 16, but I must support and this version of Edge, and i think many of developers can have problems with this version of Edge. So, i make pull request where we can check this browser, and run ponyfill for this browser