### PR TITLE
Use window-or-global for default rootElement value to fix SSR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9734,6 +9734,12 @@
         "isexe": "^2.0.0"
       }
     },
+    "window-or-global": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/window-or-global/-/window-or-global-1.0.1.tgz",
+      "integrity": "sha1-2+RboqKRqrxW1iz2bEW3+jIpRt4=",
+      "dev": true
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-terser": "^1.0.1",
-    "webpack": "^4.20.2"
+    "webpack": "^4.20.2",
+    "window-or-global": "^1.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // Dependencies
 // =============================================================================
 import getCssData          from 'get-css-data';
+import root                from 'window-or-global';
 import mergeDeep           from './merge-deep';
 import transformCss        from './transform-css';
 import { variableStore }   from './transform-css';
@@ -11,7 +12,7 @@ import { name as pkgName } from '../package.json';
 // =============================================================================
 const defaults = {
     // Sources
-    rootElement  : document,
+    rootElement  : root,
     include      : 'style,link[rel=stylesheet]',
     exclude      : '',
     // Options


### PR DESCRIPTION
We recently updated from 1.9 to 1.10 and are running into an error in our isomorphic React app: `ReferenceError: document is not defined`. On development, this leads to this line: https://github.com/jhildenbiddle/css-vars-ponyfill/blob/master/src/index.js#L14. It seems like it started with this commit: https://github.com/jhildenbiddle/css-vars-ponyfill/commit/a2f3b3a064d88ff17098f117853ad57e1ce411d0

My first thought was to call `cssVars` with a custom `rootElement` using https://github.com/purposeindustries/window-or-global:

```
import root from 'window-or-global';

class MyComponent extends PureComponent {
  componentDidMount() {
    cssVars({
      rootElement: root
    });
  }
```

This does not solve my problem, which illustrates that the error is happening when the library is imported at the top of the file, not when `cssVars` is called.

This PR uses `root` from `window-or-global` as the default value for `rootElement`.

PS: Thanks for creating this library! We're super excited to be using CSS variables on my project 🎨 