### PR TITLE
Put quotes around "import" which can be a reserved word 

### DIFF
--- a/src/stringify-css.js
+++ b/src/stringify-css.js
@@ -38,7 +38,7 @@ function stringifyCss(tree, delim = '', cb) {
         host(node) {
             return '@host' + '{' + visit(node.rules) + '}';
         },
-        import(node) {
+        'import'(node) {
             // FIXED
             return '@import ' + node.name + ';';
         },


### PR DESCRIPTION
"import" is a reserved word in some older javascript implementations (also Google shows it may be flagged by some linters).