### PR TITLE
Added option to reduce CSS calc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2894,6 +2894,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css-unit-converter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
+    },
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
@@ -7359,6 +7364,11 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7602,6 +7612,15 @@
       "requires": {
         "indent-string": "^3.0.0",
         "strip-indent": "^2.0.0"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.6.tgz",
+      "integrity": "sha512-+l5/qlQmdsbM9h6JerJ/y5vR5Ci0k93aszLNpCmbadC3nBcbRGmIBm0s9Nj59i22LvCjTGftWzdQRwdknayxhw==",
+      "requires": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -111,5 +111,7 @@
     "rollup-plugin-terser": "^5.1.2",
     "webpack": "^4.40.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "reduce-css-calc": "^2.1.6"
+  }
 }

--- a/src/transform-css.js
+++ b/src/transform-css.js
@@ -6,10 +6,11 @@
 
 // Dependencies
 // =============================================================================
-import balanced     from 'balanced-match';
-import parseCss     from './parse-css';
-import stringifyCss from './stringify-css';
-import walkCss      from './walk-css';
+import balanced      from 'balanced-match';
+import parseCss      from './parse-css';
+import stringifyCss  from './stringify-css';
+import walkCss       from './walk-css';
+import reduceCssCalc from '../node_modules/reduce-css-calc';
 
 
 // Constants & Variables
@@ -41,9 +42,11 @@ const VAR_FUNC_IDENTIFIER = 'var';
  */
 function transformCss(cssData, options = {}) {
     const defaults = {
-        preserveStatic: true,
-        preserveVars  : false,
-        variables     : {},
+        preserveStatic     : true,
+        preserveVars       : false,
+        reduceCalc         : false,
+        reduceCalcPrecision: 5,
+        variables          : {},
         onWarning() {}
     };
     const settings = Object.assign({}, defaults, options);
@@ -80,6 +83,11 @@ function transformCss(cssData, options = {}) {
                 if (resolvedValue !== decl.value) {
                     // Fix nested calc
                     resolvedValue = fixNestedCalc(resolvedValue);
+
+                    // Reduce CSS calc
+                    if (settings.reduceCalc) {
+                        resolvedValue = reduceCssCalc(resolvedValue, settings.reduceCalcPrecision);
+                    }
 
                     // Overwrite value
                     if (!settings.preserveVars) {

--- a/tests/transform-css.test.js
+++ b/tests/transform-css.test.js
@@ -177,6 +177,25 @@ describe('transform-css', function() {
 
             expect(cssOut).to.equal(expectCss);
         });
+
+        it('transforms hsl color calc', function() {
+            const cssIn     = `
+                :root {
+                    --h: 120;
+                    --s: 50%;
+                    --l: 50.12345%;
+                }
+                p { color: hsl(var(--h), var(--s), calc(var(--l) - 12%)) }
+            `;
+            const cssOut    = transformCss(cssIn, {
+                variables: parseVars(cssIn),
+                reduceCalc: true,
+                reduceCalcPrecision: 2
+            });
+            const expectCss = 'p{color:hsl(120, 50%, 38.12%);}';
+
+            expect(cssOut).to.equal(expectCss);
+        });
     });
 
     // Tests: Undefined


### PR DESCRIPTION
Added the option to reduce CSS calc expressions using https://www.npmjs.com/package/reduce-css-calc. New options are `reduceCalc` (default: `false`) and `reduceCalcPrecision` (default: `5`).

This fixes #94.