### PR TITLE
Allow blocking sync load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ let isShadowDOMReady = false;
  * @param {boolean}  [options.watch=false] Determines if a MutationObserver will
  *                   be created that will execute the ponyfill when a <link> or
  *                   <style> DOM mutation is observed
- * @param {boolean}  [options.allowSyncLoad=false] Allows blocking syncronous
+ * @param {boolean}  [options.allowSyncLoad=false] Allows blocking synchronous
  *                   loading to help with FOUC
  * @param {function} [options.onBeforeSend] Callback before XHR is sent. Passes
  *                   1) the XHR object, 2) source node reference, and 3) the

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ const defaults = {
     updateDOM     : true,  // cssVars
     updateURLs    : true,  // cssVars
     watch         : null,  // cssVars
+    allowSyncLoad : false,  // cssVars
     // Callbacks
     onBeforeSend() {},     // cssVars
     onWarning() {},        // transformCss
@@ -130,6 +131,8 @@ let isShadowDOMReady = false;
  * @param {boolean}  [options.watch=false] Determines if a MutationObserver will
  *                   be created that will execute the ponyfill when a <link> or
  *                   <style> DOM mutation is observed
+ * @param {boolean}  [options.allowSyncLoad=false] Allows blocking syncronous
+ *                   loading to help with FOUC
  * @param {function} [options.onBeforeSend] Callback before XHR is sent. Passes
  *                   1) the XHR object, 2) source node reference, and 3) the
  *                   source URL as arguments
@@ -169,6 +172,7 @@ let isShadowDOMReady = false;
  *     updateDOM     : true,
  *     updateURLs    : true,
  *     watch         : false,
+ *     allowSyncLoad : false,
  *     onBeforeSend(xhr, node, url) {},
  *     onWarning(message) {},
  *     onError(message, node, xhr, url) {},
@@ -274,7 +278,7 @@ function cssVars(options = {}) {
     }
 
     // Verify readyState to ensure all <link> and <style> nodes are available
-    if (document.readyState !== 'loading') {
+    if (document.readyState !== 'loading' || settings.allowSyncLoad) {
         // Native support
         if (isNativeSupport && settings.onlyLegacy) {
             // Apply settings.variables

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const defaults = {
     exclude       : '',
     variables     : {},    // cssVars, transformCss
     // Options
+    allowSyncLoad : false, // cssVars
     onlyLegacy    : true,  // cssVars
     preserveStatic: true,  // parseCSS
     preserveVars  : false, // transformCss
@@ -32,7 +33,6 @@ const defaults = {
     updateDOM     : true,  // cssVars
     updateURLs    : true,  // cssVars
     watch         : null,  // cssVars
-    allowSyncLoad : false,  // cssVars
     // Callbacks
     onBeforeSend() {},     // cssVars
     onWarning() {},        // transformCss
@@ -113,6 +113,8 @@ let isShadowDOMReady = false;
  *                   pairs. Property names can omit or include the leading
  *                   double-hyphen (—), and values specified will override
  *                   previous values
+ * @param {boolean}  [options.allowSyncLoad=false] Allows blocking synchronous
+ *                   loading to help with FOUC
  * @param {boolean}  [options.onlyLegacy=true] Determines if the ponyfill will
  *                   only generate legacy-compatible CSS in browsers that lack
  *                   native support (i.e., legacy browsers)
@@ -131,8 +133,6 @@ let isShadowDOMReady = false;
  * @param {boolean}  [options.watch=false] Determines if a MutationObserver will
  *                   be created that will execute the ponyfill when a <link> or
  *                   <style> DOM mutation is observed
- * @param {boolean}  [options.allowSyncLoad=false] Allows blocking synchronous
- *                   loading to help with FOUC
  * @param {function} [options.onBeforeSend] Callback before XHR is sent. Passes
  *                   1) the XHR object, 2) source node reference, and 3) the
  *                   source URL as arguments


### PR DESCRIPTION
Work to aid the removal of FOUC.

**Assumptions**
1. inline all CSS.
2. Never load vars asynchronously.

**Usage**

add options.allowSyncLoad true to cssVars

`cssVars({allowSyncLoad: true})`

This will skip the `readyState` check (Verify readyState to ensure all `<link>` and `<style>` nodes are available) as we ensure all CSS is loaded based on order to the ponyfill call in relation to the `<link>` and `<style>` nodes.