### PR TITLE
Fix: Remember variables from previous calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -393,7 +393,7 @@ function cssVars(options = {}) {
                     }
 
                     // Merge settings.variables into jobVars
-                    Object.assign(jobVars, settings.variables);
+                    Object.assign(jobVars, variableStore.user, settings.variables);
 
                     // Detect new variable declaration or value
                     hasVarChange = Boolean(


### PR DESCRIPTION
Fix to issue #99: "Do we need to provide all variables with cssVars.variables?" (https://github.com/jhildenbiddle/css-vars-ponyfill/issues/99)

Previously, calling cssVars with a new set of variables would reset any variables set in a previous call. That meant you had to include every variable with every call. Now, it uses the previous set of variables as a base for any new variables that are changing, so you only have to send the variables that have changed since the last call.