### PR TITLE
Add interface export for options typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'css-vars-ponyfill' {
-    export default function cssVars(options?: {
+    export interface CSSVarsPonyfillOptions {
         rootElement?: Document|HTMLElement;
         shadowDOM?: boolean;
         include?: string;
@@ -18,5 +18,7 @@ declare module 'css-vars-ponyfill' {
         onSuccess?(cssText: string, elm: HTMLLinkElement|HTMLStyleElement, url: string): void;
         onComplete?(cssText: string, styleElms: HTMLStyleElement[], cssVariables: {[key: string]: string}, benchmark: number): void;
         onFinally?(hasChanged: boolean, hasNativeSupport: boolean, benchmark: number): void;
-    }): void;
+    }
+    
+    export default function cssVars(options?: CSSVarsPonyfillOptions): void;
 }


### PR DESCRIPTION
Just a small change, to export the interface for css-vars-ponyfill's options rather than leaving them anonymous in the declared module. Handy if you're ever extending css-vars-ponyfill or using it within another function that can pass on config ([example](https://github.com/radioactivepesto/pollen/blob/master/src/utils/index.ts#L5))